### PR TITLE
Overhaul Thumbnail Controllers (use `thumbnails.roblox.com` API)

### DIFF
--- a/RobloxSetArchive.Api/Controllers/AssetsController.cs
+++ b/RobloxSetArchive.Api/Controllers/AssetsController.cs
@@ -27,19 +27,46 @@ public class AssetsController : ControllerBase
 
         if (!_memoryCache.TryGetValue(cacheKey, out string? thumbnailUrl) || thumbnailUrl is null)
         {
-            HttpClient httpClient = _httpClientFactory.CreateClient("Roblox");
-            HttpResponseMessage httpResponseMessage = await httpClient.GetAsync($"/item-thumbnails?params=[{{assetId:{id}}}]");
+            HttpClient httpClient = _httpClientFactory.CreateClient("RobloxThumbnails");
 
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                return StatusCode((int)httpResponseMessage.StatusCode);
+            const int maxRetries = 5;
+            const int delayMilliseconds = 500;
+            List<ThumbnailApiModelContents>? thumbnails = null;
 
-            string response = await httpResponseMessage.Content.ReadAsStringAsync();
-            List<ThumbnailApiModel>? thumbnails = JsonSerializer.Deserialize<List<ThumbnailApiModel>>(response);
+            for (int attempt = 0; attempt < maxRetries; attempt++)
+            {
+                HttpResponseMessage httpResponseMessage = await httpClient.GetAsync($"v1/assets?assetIds={id}&returnPolicy=PlaceHolder&size=420x420&format=webp");
 
-            if (thumbnails is null || thumbnails.Count < 1)
-                return NotFound();
+                if (!httpResponseMessage.IsSuccessStatusCode)
+                    return StatusCode((int)httpResponseMessage.StatusCode);
 
-            thumbnailUrl = thumbnails[0].thumbnailUrl;
+                string response = await httpResponseMessage.Content.ReadAsStringAsync();
+
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var result = JsonSerializer.Deserialize<ThumbnailApiModel>(response, options);
+
+                thumbnails = result?.Data;
+                if (thumbnails == null || thumbnails.Count == 0)
+                    return NotFound();
+
+                var state = thumbnails[0].State;
+
+                if (string.Equals(state, "Completed", StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                if (string.Equals(state, "Blocked", StringComparison.OrdinalIgnoreCase))
+                    return StatusCode(403, $"HTTP 403 Forbidden: Thumbnail status is 'Blocked'.");
+
+                if (!string.Equals(state, "Pending", StringComparison.OrdinalIgnoreCase))
+                    return StatusCode(500, $"HTTP 500 Internal Server Error: Unexpected thumbnail state: {state}");
+
+                await Task.Delay(delayMilliseconds);
+            }
+
+            if (thumbnails == null || !string.Equals(thumbnails[0].State, "Completed", StringComparison.OrdinalIgnoreCase))
+                return StatusCode(504, "HTTP 504 Gateway Timeout: Thumbnail still pending after retries");
+
+            thumbnailUrl = thumbnails[0].ImageUrl;
 
             var cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(DateTime.Now.AddDays(7));
 

--- a/RobloxSetArchive.Api/Controllers/UsersController.cs
+++ b/RobloxSetArchive.Api/Controllers/UsersController.cs
@@ -72,19 +72,46 @@ public class UsersController : ControllerBase
 
         if (!_memoryCache.TryGetValue(cacheKey, out string? thumbnailUrl) || thumbnailUrl is null)
         {
-            HttpClient httpClient = _httpClientFactory.CreateClient("Roblox");
-            HttpResponseMessage httpResponseMessage = await httpClient.GetAsync($"/avatar-thumbnails?params=[{{userId:{id},imageSize:\"large\"}}]");
+            HttpClient httpClient = _httpClientFactory.CreateClient("RobloxThumbnails");
 
-            if (!httpResponseMessage.IsSuccessStatusCode)
-                return StatusCode((int)httpResponseMessage.StatusCode);
+            const int maxRetries = 5;
+            const int delayMilliseconds = 500;
+            List<ThumbnailApiModelContents>? thumbnails = null;
 
-            string response = await httpResponseMessage.Content.ReadAsStringAsync();
-            List<ThumbnailApiModel>? thumbnails = JsonSerializer.Deserialize<List<ThumbnailApiModel>>(response);
+            for (int attempt = 0; attempt < maxRetries; attempt++)
+            {
+                HttpResponseMessage httpResponseMessage = await httpClient.GetAsync($"/v1/users/avatar-headshot?userIds={id}&size=150x150&format=Webp&isCircular=false");
 
-            if (thumbnails is null || thumbnails.Count < 1)
-                return NotFound();
+                if (!httpResponseMessage.IsSuccessStatusCode)
+                    return StatusCode((int)httpResponseMessage.StatusCode);
 
-            thumbnailUrl = thumbnails[0].thumbnailUrl;
+                string response = await httpResponseMessage.Content.ReadAsStringAsync();
+
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var result = JsonSerializer.Deserialize<ThumbnailApiModel>(response, options);
+
+                thumbnails = result?.Data;
+                if (thumbnails == null || thumbnails.Count == 0)
+                    return NotFound();
+
+                var state = thumbnails[0].State;
+
+                if (string.Equals(state, "Completed", StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                if (string.Equals(state, "Blocked", StringComparison.OrdinalIgnoreCase))
+                    return StatusCode(403, $"HTTP 403 Forbidden: Thumbnail status is 'Blocked'.");
+
+                if (!string.Equals(state, "Pending", StringComparison.OrdinalIgnoreCase))
+                    return StatusCode(500, $"HTTP 500 Internal Server Error: Unexpected thumbnail state: {state}");
+
+                await Task.Delay(delayMilliseconds);
+            }
+
+            if (thumbnails == null || !string.Equals(thumbnails[0].State, "Completed", StringComparison.OrdinalIgnoreCase))
+                return StatusCode(504, "HTTP 504 Gateway Timeout: Thumbnail still pending after retries");
+
+            thumbnailUrl = thumbnails[0].ImageUrl;
 
             var cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(DateTime.Now.AddDays(1));
 

--- a/RobloxSetArchive.Api/Models/ThumbnailApiModel.cs
+++ b/RobloxSetArchive.Api/Models/ThumbnailApiModel.cs
@@ -1,17 +1,23 @@
+using System.Text.Json.Serialization;
+
 namespace RobloxSetArchive.Api.Models;
 
-// class ThumbnailApiModel
-// {
-//     public ThumbnailApiModelContents d { get; set;}
-// }
-
-// class ThumbnailApiModelContents
-// {
-//     public bool final { get; set; }
-//     public string url { get; set; } = null!;
-// }
-
-class ThumbnailApiModel
+public class ThumbnailApiModel
 {
-    public string thumbnailUrl { get; set; } = null!;
+    public List<ThumbnailApiModelContents> Data { get; set; } = new();
+}
+
+public class ThumbnailApiModelContents
+{
+    [JsonPropertyName("targetId")]
+    public int TargetId { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = "";
+
+    [JsonPropertyName("imageUrl")]
+    public string ImageUrl { get; set; } = "";
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "";
 }

--- a/RobloxSetArchive.Api/Program.cs
+++ b/RobloxSetArchive.Api/Program.cs
@@ -19,6 +19,11 @@ builder.Services.AddHttpClient("Roblox", httpClient =>
     httpClient.BaseAddress = new Uri("https://www.roblox.com");
     httpClient.DefaultRequestHeaders.Add("User-Agent", "Roblox/WinInet");
 });
+builder.Services.AddHttpClient("RobloxThumbnails", httpClient => 
+{
+    httpClient.BaseAddress = new Uri("https://thumbnails.roblox.com");
+    httpClient.DefaultRequestHeaders.Add("User-Agent", "Roblox/WinInet");
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
This PR adds support for `thumbnails.roblox.com`, replacing `roblox.com/user-thumbnails` and `roblox.com/avatar-thumbnails`. To deal with the API returning a state of "Pending", I implemented a retry loop in the controllers.

Closes #4.